### PR TITLE
Use array index for tweet keys

### DIFF
--- a/src/TweetList.js
+++ b/src/TweetList.js
@@ -1,11 +1,9 @@
 import SingleTweet from "./SingleTweet";
 
 function TweetList(props) {
-  const tweetList = props.tweets.map((tweet) => (
-    <SingleTweet key={tweet.name + tweet.message} name={tweet.name} message={tweet.message}></SingleTweet>
+  const tweetList = props.tweets.map((tweet, index) => (
+    <SingleTweet key={index} name={tweet.name} message={tweet.message}></SingleTweet>
   ));
-  return (
-    <>{tweetList}</>
-  );
+  return <>{tweetList}</>;
 }
 export default TweetList;


### PR DESCRIPTION
## Summary
- Use array index as a unique key when rendering tweets to avoid React warnings

## Testing
- `CI=true npm test -- --runTestsByPath src/TweetList.test.js`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a81ef52a508328b5879b54dd8f9b89