### PR TITLE
Add TweetForm submission test

### DIFF
--- a/src/TweetForm.js
+++ b/src/TweetForm.js
@@ -11,8 +11,15 @@ function TweetForm(props) {
     setMessage(e.target.value);
   };
 
+  const handleSubmit = function (e) {
+    e.preventDefault();
+    props.onSubmit(e, name, message);
+    setName("");
+    setMessage("");
+  };
+
   return (
-    <form id="tweetform" onSubmit={(e) => props.onSubmit(e, name, message)}>
+    <form id="tweetform" onSubmit={handleSubmit}>
       <label className="form-label" htmlFor="displayname">
         Display name:
       </label>

--- a/src/TweetForm.js
+++ b/src/TweetForm.js
@@ -11,7 +11,7 @@ function TweetForm(props) {
     setMessage(e.target.value);
   };
 
-  const handleSubmit = function (e) {
+  const handleTweetSubmit = function (e) {
     e.preventDefault();
     props.onSubmit(e, name, message);
     setName("");
@@ -19,7 +19,7 @@ function TweetForm(props) {
   };
 
   return (
-    <form id="tweetform" onSubmit={handleSubmit}>
+    <form id="tweetform" onSubmit={handleTweetSubmit}>
       <label className="form-label" htmlFor="displayname">
         Display name:
       </label>

--- a/src/TweetForm.test.js
+++ b/src/TweetForm.test.js
@@ -1,0 +1,27 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import TweetForm from "./TweetForm";
+
+test("submits name and message and clears inputs", async () => {
+  const handleSubmit = jest.fn();
+  render(<TweetForm onSubmit={handleSubmit} />);
+
+  const nameInput = screen.getByLabelText(/display name/i);
+  const messageInput = screen.getByLabelText(/message/i);
+
+  await act(async () => {
+    await userEvent.type(nameInput, "Alice");
+    await userEvent.type(messageInput, "Hello there");
+    await userEvent.click(screen.getByRole("button", { name: /submit/i }));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith(
+    expect.anything(),
+    "Alice",
+    "Hello there"
+  );
+  expect(nameInput).toHaveValue("");
+  expect(messageInput).toHaveValue("");
+});
+

--- a/src/TweetForm.test.js
+++ b/src/TweetForm.test.js
@@ -1,5 +1,6 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { act } from "react";
 import "@testing-library/jest-dom";
 import TweetForm from "./TweetForm";
 


### PR DESCRIPTION
## Summary
- reset TweetForm inputs on submission and prevent default form behavior
- test that TweetForm submits entered values and clears the form

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a81ef7a4708328be967805481a1f41